### PR TITLE
Log Additions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,6 @@ autoNICER is a program that allows individuals wanting to work with data from th
 
 ### v1.0.2
 - Limited the astropy dependency to versions less than v5.1 since the changes in astropy v5.1 mess with the time conversions. (Future versions will make autonicer compatable with astropy v5.1)
+
+### v1.1.0
+- Added two new columns to the output log: CALDB_ver and DateTime. Also changed the "Name" column to "OBSID". This should lead to less confusion and give the user a better idea of which calibration version was used to process their data, and at what point in time they processed that data.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ Thank you.
 This software is licensed under the Apache 2.0 license, so it is free and open source for you to use.
 This project unaffiliated with the NICER team, NASA, the Goddard Space Flight Center (GSFC), and HEASARC. Under no circumstances should anyone consider this project endorsed or recommended by the afformentioned agencies and organizations.
 
+## Watch a video Tutorial on how to use autoNICER
+After v1.0.2 I a made a video going over autoNICER and demoing some of its functionality.
+See it here:
+<https://youtu.be/q23dvn3Da7Q>
+
+
 ## Pre-Requisite Software
 - HEASoft v6.29c, v6.30, RECOMMENDED v6.30.1 <https://heasarc.gsfc.nasa.gov/docs/software/lheasoft/>
 
@@ -27,18 +33,18 @@ A video tutorial on how to setup Remote CALDB can be found here: <https://youtu.
 
 ## Installation
 
-For standard non-dev use cases (download the .whl or .tar.gz release)(https://github.com/nkphysics/autoNICER/releases/tag/v1.0.1) (normal pip installation coming soon maybe):
+For standard non-dev use cases download via pip.
 
-	$ pip3 install autonicer-1.0.1-py3-none-any.whl
+	$ pip3 autonicer
 
 OR
 
-	$ pip3 install autonicer-1.0.1.tar.gz
+	$ pip install autonicer
 
 For development cases:
 - Clone the repo
 - cd into the project directory
-- make sure you are using poetry to help manage dependencies
+- Run `poetry install` to install the needed dependencies
 - Start working!
 
 ## Basic Usage

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A video tutorial on how to setup Remote CALDB can be found here: <https://youtu.
 
 For standard non-dev use cases download via pip.
 
-	$ pip3 autonicer
+	$ pip3 install autonicer
 
 OR
 

--- a/autonicer/autonicer.py
+++ b/autonicer/autonicer.py
@@ -215,7 +215,8 @@ class AutoNICER(object):
 		newline = pd.DataFrame({
 				"Input":[f"{base_dir}/{obsid}/xti/event_cl/bc{obsid}_0mpu7_cl.evt"],
 				"Name":[f"NI{obsid}"],
-				"CALDB_ver": [f"{self.caldb_ver}"]
+				"CALDB_ver": [f"{self.caldb_ver}"],
+				"DateTime": [f"{datetime.datetime.now()}"]
 				},
 		)
 		q = pd.concat([q, newline])
@@ -269,7 +270,7 @@ class AutoNICER(object):
 				read_q = pd.read_csv(self.q_path)
 				self.add2q(read_q, base_dir, obsid)
 			elif self.q_set == "y" and self.q_path == 0:
-				q = pd.DataFrame({"Input":[], "Name":[], "CALDB_ver": []})
+				q = pd.DataFrame({"Input":[], "Name":[], "CALDB_ver": [], "DateTime": []})
 				self.q_path = f"{base_dir}/{self.q_name}.csv"
 				self.add2q(q, base_dir, obsid)
 			else:

--- a/autonicer/autonicer.py
+++ b/autonicer/autonicer.py
@@ -25,6 +25,7 @@ class AutoNICER(object):
 		self.months = []
 		self.ras = []
 		self.decs = []
+		self.caldb_ver = ""
 		
 		print(colored("##############  Auto NICER  ##############", "cyan"))
 		print()
@@ -82,6 +83,11 @@ class AutoNICER(object):
 			cycle.append(int(convo))
 		self.xti["Cycle#"] = cycle
 		return self.xti
+		
+	def get_caldb_ver(self):
+		caldb = sp.run("nicaldbver", shell=True, capture_output=True, encoding="utf-8")
+		convo = str(caldb.stdout).split("\n")
+		return convo[0]
 
 	def sel_obs(self, enter):
 		self.observations.append(enter)

--- a/autonicer/autonicer.py
+++ b/autonicer/autonicer.py
@@ -214,7 +214,7 @@ class AutoNICER(object):
 	def add2q(self, q, base_dir, obsid):
 		newline = pd.DataFrame({
 				"Input":[f"{base_dir}/{obsid}/xti/event_cl/bc{obsid}_0mpu7_cl.evt"],
-				"Name":[f"NI{obsid}"],
+				"OBSID":[f"NI{obsid}"],
 				"CALDB_ver": [f"{self.caldb_ver}"],
 				"DateTime": [f"{datetime.datetime.now()}"]
 				},

--- a/autonicer/autonicer.py
+++ b/autonicer/autonicer.py
@@ -214,7 +214,8 @@ class AutoNICER(object):
 	def add2q(self, q, base_dir, obsid):
 		newline = pd.DataFrame({
 				"Input":[f"{base_dir}/{obsid}/xti/event_cl/bc{obsid}_0mpu7_cl.evt"],
-				"Name":[f"NI{obsid}"]
+				"Name":[f"NI{obsid}"],
+				"CALDB_ver": [f"{self.caldb_ver}"]
 				},
 		)
 		q = pd.concat([q, newline])
@@ -247,6 +248,7 @@ class AutoNICER(object):
 			sp.call(f"{pull_templ}/log/ {end_args}", shell=True)
 			print(colored("Downloading auxil data...", "green"))
 			sp.call(f"{pull_templ}/auxil/ {end_args}", shell=True)
+			self.caldb_ver = self.get_caldb_ver()
 			sp.call(f"nicerl2 indir={obsid}/ clobber=yes", shell=True)
 			if self.bc_sel.lower() == "n":
 				pass
@@ -267,7 +269,7 @@ class AutoNICER(object):
 				read_q = pd.read_csv(self.q_path)
 				self.add2q(read_q, base_dir, obsid)
 			elif self.q_set == "y" and self.q_path == 0:
-				q = pd.DataFrame({"Input":[], "Name":[]})
+				q = pd.DataFrame({"Input":[], "Name":[], "CALDB_ver": []})
 				self.q_path = f"{base_dir}/{self.q_name}.csv"
 				self.add2q(q, base_dir, obsid)
 			else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "autonicer"
-version = "1.0.2"
+version = "1.1.0"
 description = "A program that retrieves NICER observational data sets and performs a default data reduction process on the NICER observational data"
 authors = ["Tsar Bomba Nick <njkuechel@protonmail.com>"]
 license = "Apache-2.0"

--- a/tests/test_autonicer.py
+++ b/tests/test_autonicer.py
@@ -53,3 +53,6 @@ def test_back():
 	assert len(an.ras) == len(an.observations)
 	assert len(an.decs) == len(an.ras)
 	
+def get_caldb_ver():
+	assert an.get_caldb_ver() == "xti20210707"
+	


### PR DESCRIPTION
I have gone in and added the following two new columns to the output log.

- CALDB_ver
- DateTime
This now gives the following columns in order [Input, OBSID, CALDB_ver, DateTime].
This, in theory, will be better for a user to see what calibration files were used when data was retrieved and reduced. It will also give them an exact timestamp of when they pulled and reduced the data. 

This should also help out with the future plans of adding reprocessing functionality, and identifying which datasets an analyst should reprocess with more recent calibrations as they come out, of course if the choose to.