### PR TITLE
Limit cal pull

### DIFF
--- a/autonicer/autonicer.py
+++ b/autonicer/autonicer.py
@@ -18,6 +18,7 @@ import datetime
 import gzip
 import shutil
 import warnings
+import glob
 from astropy.utils.exceptions import AstropyWarning
 
 
@@ -284,8 +285,8 @@ class AutoNICER(object):
         print("Compressing ufa.evt files")
         print("----------------------------------------------------------")
         # files and loop to compress the ufa files
-        files = sp.run("ls *ufa.evt", shell=True, capture_output=True, encoding="utf-8")
-        for i in str(files.stdout).split("\n"):
+        files = glob.glob("*ufa.evt")
+        for i in files:
             gz_comp(i)
 
         # compression of the non-bc mpu7_cl.evt file if barycenter correction is selected

--- a/autonicer/reprocess.py
+++ b/autonicer/reprocess.py
@@ -33,17 +33,14 @@ class Reprocess:
         Gets all cl.evt files associated with an existing NICER dataset
         """
         os.chdir(f"xti/event_cl/")
-        files = sp.run("ls *cl.evt", shell=True, capture_output=True, encoding="utf-8")
-        filelist = []
-        for i in str(files.stdout).split("\n"):
-            if i != "":
-                filelist.append(i)
-                if self.src == None:
-                    self.get_meta(i)
+        files = glob.glob("*cl.evt")
+        for i in files:
+            if self.src == None:
+                self.get_meta(i)
             if i == f"bc{self.obsid}_0mpu7_cl.evt":
                 self.bc_det = True
         os.chdir(self.base_dir)
-        return filelist
+        return files
 
     def get_meta(self, infile):
         """

--- a/autonicer/reprocess.py
+++ b/autonicer/reprocess.py
@@ -12,8 +12,11 @@ import glob
 
 
 class Reprocess:
-    def __init__(self):
-        self.curr_caldb = autonicer.get_caldb_ver()
+    def __init__(self, cals=None):
+        if cals is None:
+            self.curr_caldb = autonicer.get_caldb_ver()
+        else:
+            self.curr_caldb = cals
         self.base_dir = os.getcwd()
         self.last_caldb = None
         self.calstate = None
@@ -128,11 +131,11 @@ class Reprocess:
                 an.nicer_compress()
 
 
-def reprocess_check(argp):
+def reprocess_check(argp, cals=None):
     """
     Parses and Runs --reprocess and --checkcal
     """
-    check = Reprocess()
+    check = Reprocess(cals)
     if argp.checkcal is True:
         check.checkcal()
     if argp.reprocess is True:
@@ -145,13 +148,14 @@ def inlist(argp):
     or .evt files
     """
     cwd = os.getcwd()
+    curr_cals = autonicer.get_caldb_ver()
     try:
         df = pd.read_csv(f"{argp.inlist}")
         for i in df["Input"]:
             path_sep = i.split("/xti/event_cl/")
             os.chdir(path_sep[0])
             if argp.checkcal is True or argp.reprocess is True:
-                reprocess_check(argp)
+                reprocess_check(argp, curr_cals)
             os.chdir(cwd)
 
     except FileNotFoundError:


### PR DESCRIPTION
Added in limitations to how much autonicer.get_caldb_ver() is called when passing in an `--inlist` file as reported in #32 

Also migrated a few missed sp.run(ls) commands  to glob