### PR TITLE
Compress cl

### DIFF
--- a/autonicer/__init__.py
+++ b/autonicer/__init__.py
@@ -51,6 +51,7 @@ def run(args=None):
     )
 
     p.add_argument(
+        "-i",
         "-inlist",
         "--inlist",
         help="Input .csv list with path to OBSID dirs or mpu7_cl.evt files for use with --reprocess and/or --checkcal",

--- a/autonicer/autonicer.py
+++ b/autonicer/autonicer.py
@@ -299,7 +299,8 @@ class AutoNICER(object):
             print("----------------------------------------------------------")
             cl_file = glob.glob("ni*cl.evt")
             for i in cl_file:
-                gz_comp(i)
+                print(gz_comp(i))
+        print()
 
     def add2q(self, q, base_dir, obsid):
         """

--- a/autonicer/autonicer.py
+++ b/autonicer/autonicer.py
@@ -294,18 +294,12 @@ class AutoNICER(object):
                 print(j.result())
 
         # compression of the non-bc mpu7_cl.evt file if barycenter correction is selected
-        # if self.bc_sel.lower() == "n":
-        #     pass
-        # else:
-        #     print("")
-        #     print("Compressing cl.evt files")
-        #     print("----------------------------------------------------------")
-        # files and liip to compress the cl files
-        #     cl_file = sp.run(
-        #         "ls ni*cl.evt", shell=True, capture_output=True, encoding="utf-8"
-        #     )
-        #     for i in str(cl_file.stdout).split("\n"):
-        #         gz_comp(i)
+        if self.bc_sel.lower() == "y":
+            print("Compressing cl.evt files")
+            print("----------------------------------------------------------")
+            cl_file = glob.glob("ni*cl.evt")
+            for i in cl_file:
+                gz_comp(i)
 
     def add2q(self, q, base_dir, obsid):
         """

--- a/autonicer/autonicer.py
+++ b/autonicer/autonicer.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 
 # AutoNICER
-# Copyright 2022 Nicholas Kuechel
+# Copyright 2022-2023 Nicholas Kuechel
 # License Apache 2.0
 
 import subprocess as sp

--- a/autonicer/reprocess.py
+++ b/autonicer/reprocess.py
@@ -1,3 +1,7 @@
+# AutoNICER
+# Copyright 2022-2023 Nicholas Kuechel
+# License Apache 2.0
+
 import autonicer
 import subprocess as sp
 import os

--- a/autonicer/reprocess.py
+++ b/autonicer/reprocess.py
@@ -183,13 +183,16 @@ def inlist(argp):
     curr_cals = autonicer.get_caldb_ver()
     try:
         if len(argp.inlist) == 1:
-            df = pd.read_csv(f"{argp.inlist[0]}")
-            for i in df["Input"]:
-                path_sep = i.split("/xti/event_cl/")
-                os.chdir(path_sep[0])
-                if argp.checkcal is True or argp.reprocess is True:
-                    reprocess_check(argp, curr_cals)
-                os.chdir(cwd)
+            try:
+                df = pd.read_csv(f"{argp.inlist[0]}")
+                for i in df["Input"]:
+                    path_sep = i.split("/xti/event_cl/")
+                    os.chdir(path_sep[0])
+                    if argp.checkcal is True or argp.reprocess is True:
+                        reprocess_check(argp, curr_cals)
+                    os.chdir(cwd)
+            except IsADirectoryError:
+                raise FileNotFoundError
         else:
             raise FileNotFoundError
 

--- a/tests/test_autonicer.py
+++ b/tests/test_autonicer.py
@@ -286,6 +286,15 @@ def test_checkcal_reprocess(capsys):
     assert unix2 in out
 
 
+def test_inlist_singledir(capsys):
+    os.chdir(f"{base_dir}/data")
+    os.remove("test.csv")
+    autonicer.run(["--checkcal", "-inlist", "*"])
+    passing = f"Migrating to {colored('3013010102', 'cyan')}"
+    out, err = capsys.readouterr()
+    assert passing in out
+
+
 def test_inlist_readin(capsys):
     os.chdir(f"{base_dir}")
     files = ["requirements.txt", "README.md", "fail.lis"]

--- a/tests/test_autonicer.py
+++ b/tests/test_autonicer.py
@@ -288,9 +288,9 @@ def test_checkcal_reprocess(capsys):
 
 def test_inlist_readin(capsys):
     os.chdir(f"{base_dir}")
-    files = ["requirements.txt", "README.md"]
+    files = ["requirements.txt", "README.md", "fail.lis"]
     for i in files:
-        autonicer.run(["--checkcal", "--inlist", f"{i}"])
+        autonicer.run(["--checkcal", "-i", f"{i}"])
     out, err = capsys.readouterr()
     pd_err = "Unable to resolve --inlist README.md"
     key_err = "requirements.txt format not readable"

--- a/tests/test_autonicer.py
+++ b/tests/test_autonicer.py
@@ -132,9 +132,9 @@ def test_pullreduce():
     ufa_gz = glob.glob("*ufa.evt.gz")
     assert len(ufa_gz) == 8
     cl = glob.glob("*cl.evt")
-    assert len(cl) == 2
+    assert len(cl) == 1
     cl_gz = glob.glob("*cl.evt.gz")
-    assert len(cl_gz) == 0
+    assert len(cl_gz) == 1
     os.chdir(f"{base_dir}")
 
 
@@ -146,9 +146,9 @@ def setup_reprocess():
 
 def test_get_clevts(setup_reprocess):
     check = setup_reprocess
-    assert len(check.clevts) == 2
+    assert len(check.clevts) == 1
     for i in check.clevts:
-        assert i == "bc3013010102_0mpu7_cl.evt" or i == "ni3013010102_0mpu7_cl.evt"
+        assert i == "bc3013010102_0mpu7_cl.evt"
     assert check.bc_det is True
     os.chdir(f"{base_dir}/data/")
 
@@ -157,8 +157,7 @@ def test_getmeta(setup_reprocess):
     check = setup_reprocess
     assert check.obsid == "3013010102"
     assert check.src == "PSR_B0531+21"
-    assert check.ra == 83.63308
-    assert check.dec == 22.01449
+    assert check.reprocess_err == None
     os.chdir(f"{base_dir}/data/")
 
 


### PR DESCRIPTION
- Re added in the compression of mpu7_cl.evt  non barycenter corrected file if barycenter correction takes place
- Fixed error with only one dir passing through the inlist which was killing the process
- Minor test enhancements