### PR TITLE
Unexpected target fix

### DIFF
--- a/autonicer/reprocess.py
+++ b/autonicer/reprocess.py
@@ -70,6 +70,13 @@ class Reprocess:
         hdul = fits.open(infile)
         try:
             self.obsid = hdul[0].header["OBS_ID"]
+        except KeyError:
+            try:
+                self.obsid = hdul[1].header["OBS_ID"]
+            except KeyError:
+                print(colored("Unable to idenify OBSID", "red"))
+                self.reprocess_err = True
+        try:
             self.ra = hdul[0].header["RA_OBJ"]
             self.dec = hdul[0].header["DEC_OBJ"]
 

--- a/autonicer/reprocess.py
+++ b/autonicer/reprocess.py
@@ -70,11 +70,11 @@ class Reprocess:
         """
         hdul = fits.open(infile)
         try:
-            self.obsid = hdul[1].header["OBS_ID"]
-            self.ra = hdul[1].header["RA_OBJ"]
-            self.dec = hdul[1].header["DEC_OBJ"]
+            self.obsid = hdul[0].header["OBS_ID"]
+            self.ra = hdul[0].header["RA_OBJ"]
+            self.dec = hdul[0].header["DEC_OBJ"]
             try:
-                self.src = hdul[1].header["OBJECT"]
+                self.src = hdul[0].header["OBJECT"]
                 if self.src is None or self.src == "":
                     self.src = False
             except KeyError:

--- a/autonicer/reprocess.py
+++ b/autonicer/reprocess.py
@@ -58,8 +58,8 @@ class Reprocess:
         files = glob.glob("*cl.evt")
         for i in files:
             self.get_meta(i)
-            if i == f"bc{self.obsid}_0mpu7_cl.evt":
-                self.bc_det = True
+        if f"bc{self.obsid}_0mpu7_cl.evt" in files:
+            self.bc_det = True
         os.chdir(self.base_dir)
         return files
 

--- a/autonicer/reprocess.py
+++ b/autonicer/reprocess.py
@@ -75,6 +75,8 @@ class Reprocess:
             self.dec = hdul[1].header["DEC_OBJ"]
             try:
                 self.src = hdul[1].header["OBJECT"]
+                if self.src is None or self.src == "":
+                    self.src = False
             except KeyError:
                 print("Unable to identify Object -> IS OK")
                 print("Proceeding with Reduction...")

--- a/autonicer/reprocess.py
+++ b/autonicer/reprocess.py
@@ -41,7 +41,7 @@ class Reprocess:
         self.base_dir = os.getcwd()
         self.last_caldb = None
         self.calstate = None
-        self.src = None
+        self.src = False
         self.obsid = None
         self.ra = None
         self.dec = None
@@ -57,8 +57,7 @@ class Reprocess:
         os.chdir(f"xti/event_cl/")
         files = glob.glob("*cl.evt")
         for i in files:
-            if self.src == None:
-                self.get_meta(i)
+            self.get_meta(i)
             if i == f"bc{self.obsid}_0mpu7_cl.evt":
                 self.bc_det = True
         os.chdir(self.base_dir)
@@ -73,21 +72,14 @@ class Reprocess:
             self.obsid = hdul[0].header["OBS_ID"]
             self.ra = hdul[0].header["RA_OBJ"]
             self.dec = hdul[0].header["DEC_OBJ"]
-            try:
-                self.src = hdul[0].header["OBJECT"]
-                if self.src is None or self.src == "":
-                    self.src = False
-            except KeyError:
-                print("Unable to identify Object -> IS OK")
-                print("Proceeding with Reduction...")
-                self.src = False
+
         except KeyError:
             print(colored("Unable to identify required metadata.", "red"))
             print("Consider Re-downloading and reducing this dataset")
             print("OR")
             print("Try nicerl2 manually")
             self.reprocess_err = True
-        return self.src, self.reprocess_err
+        return self.reprocess_err
 
     def checkcal(self):
         """

--- a/tests/test_autonicer.py
+++ b/tests/test_autonicer.py
@@ -173,8 +173,8 @@ def test_nometa(capsys):
     for i in cl_files:
         hdul = fits.open(i)
         for j, k in metadata.items():
-            metadata[j] = hdul[1].header[j]
-            del hdul[1].header[j]
+            metadata[j] = hdul[0].header[j]
+            del hdul[0].header[j]
         hdul.writeto(i, overwrite=True)
         hdul.close()
     os.chdir(f"{base_dir}/data/3013010102")
@@ -190,12 +190,12 @@ def test_nometa(capsys):
     os.chdir(f"{base_dir}/data/3013010102/xti/event_cl/")
     for i in cl_files:
         hdul = fits.open(i)
-        hdul[1].header["OBS_ID"] = metadata["OBS_ID"]
-        hdul[1].header["RA_OBJ"] = metadata["RA_OBJ"]
-        hdul[1].header["DEC_OBJ"] = metadata["DEC_OBJ"]
-        assert hdul[1].header["OBS_ID"] == hdul[0].header["OBS_ID"]
-        # assert hdul[1].header["RA_OBJ"] == hdul[0].header["RA_OBJ"]
-        # assert hdul[1].header["DEC_OBJ"] == hdul[0].header["DEC_OBJ"]
+        hdul[0].header["OBS_ID"] = metadata["OBS_ID"]
+        hdul[0].header["RA_OBJ"] = metadata["RA_OBJ"]
+        hdul[0].header["DEC_OBJ"] = metadata["DEC_OBJ"]
+        assert metadata["OBS_ID"] == hdul[0].header["OBS_ID"]
+        assert metadata["RA_OBJ"] == hdul[0].header["RA_OBJ"]
+        assert metadata["DEC_OBJ"] == hdul[0].header["DEC_OBJ"]
         hdul.writeto(i, overwrite=True)
         hdul.close()
     os.chdir(f"{base_dir}/data/3013010102")

--- a/tests/test_autonicer.py
+++ b/tests/test_autonicer.py
@@ -165,14 +165,15 @@ def test_nometa(capsys):
     os.chdir(f"{base_dir}/data/3013010102/xti/event_cl/")
     cl_files = glob.glob("*cl.evt")
     metadata = {
-        "OBJECT": "PSR_B0531+21",
-        "OBS_ID": "3013010102",
-        "RA_OBJ": 83.63308,
-        "DEC_OBJ": 22.01449,
+        "OBJECT": None,
+        "OBS_ID": None,
+        "RA_OBJ": None,
+        "DEC_OBJ": None,
     }
     for i in cl_files:
         hdul = fits.open(i)
         for j, k in metadata.items():
+            metadata[j] = hdul[1].header[j]
             del hdul[1].header[j]
         hdul.writeto(i, overwrite=True)
         hdul.close()
@@ -193,8 +194,8 @@ def test_nometa(capsys):
         hdul[1].header["RA_OBJ"] = metadata["RA_OBJ"]
         hdul[1].header["DEC_OBJ"] = metadata["DEC_OBJ"]
         assert hdul[1].header["OBS_ID"] == hdul[0].header["OBS_ID"]
-        assert hdul[1].header["RA_OBJ"] == hdul[0].header["RA_OBJ"]
-        assert hdul[1].header["DEC_OBJ"] == hdul[0].header["DEC_OBJ"]
+        # assert hdul[1].header["RA_OBJ"] == hdul[0].header["RA_OBJ"]
+        # assert hdul[1].header["DEC_OBJ"] == hdul[0].header["DEC_OBJ"]
         hdul.writeto(i, overwrite=True)
         hdul.close()
     os.chdir(f"{base_dir}/data/3013010102")

--- a/tests/test_autonicer.py
+++ b/tests/test_autonicer.py
@@ -164,7 +164,6 @@ def test_nometa(capsys):
     os.chdir(f"{base_dir}/data/3013010102/xti/event_cl/")
     cl_files = glob.glob("*cl.evt")
     metadata = {
-        "OBJECT": None,
         "OBS_ID": None,
         "RA_OBJ": None,
         "DEC_OBJ": None,

--- a/tests/test_autonicer.py
+++ b/tests/test_autonicer.py
@@ -156,7 +156,6 @@ def test_get_clevts(setup_reprocess):
 def test_getmeta(setup_reprocess):
     check = setup_reprocess
     assert check.obsid == "3013010102"
-    assert check.src == "PSR_B0531+21"
     assert check.reprocess_err == None
     os.chdir(f"{base_dir}/data/")
 
@@ -201,8 +200,6 @@ def test_nometa(capsys):
     os.chdir(f"{base_dir}/data/3013010102")
     check2 = autonicer.Reprocess()
     out2, err2 = capsys.readouterr()
-    fail2 = "Unable to identify Object -> IS OK"
-    assert fail2 in out2
     assert fail not in out2
     assert check2.reprocess_err is None
     assert check2.src is False


### PR DESCRIPTION
Fixed issues with OSBID metadata and OBJECT metadata, and updated tests. 
This is a direct fix for #44.

Updated Tests report:

======================================== test session starts ========================================
platform linux -- Python 3.10.6, pytest-7.2.0, pluggy-1.0.0 -- /home/nick/.cache/pypoetry/virtualenvs/autonicer-m0AGjpC8-py3.10/bin/python
cachedir: .pytest_cache
rootdir: /home/nick/autoNICER
plugins: cov-4.0.0
collected 26 items                                                                                  

tests/test_autonicer.py::test_passin PASSED                                                   [  3%]
tests/test_autonicer.py::test_call_nicer PASSED                                               [  7%]
tests/test_autonicer.py::test_make_cycle PASSED                                               [ 11%]
tests/test_autonicer.py::test_single_sel PASSED                                               [ 15%]
tests/test_autonicer.py::test_showsettings PASSED                                             [ 19%]
tests/test_autonicer.py::test_short_entry PASSED                                              [ 23%]
tests/test_autonicer.py::test_wrong_obsid PASSED                                              [ 26%]
tests/test_autonicer.py::test_cycle_sel PASSED                                                [ 30%]
tests/test_autonicer.py::test_rm_single_sel PASSED                                            [ 34%]
tests/test_autonicer.py::test_back PASSED                                                     [ 38%]
tests/test_autonicer.py::test_duplicate PASSED                                                [ 42%]
tests/test_autonicer.py::test_rm_all PASSED                                                   [ 46%]
tests/test_autonicer.py::test_get_caldbver PASSED                                             [ 50%]
tests/test_autonicer.py::test_pullreduce PASSED                                               [ 53%]
tests/test_autonicer.py::test_get_clevts PASSED                                               [ 57%]
tests/test_autonicer.py::test_getmeta PASSED                                                  [ 61%]
tests/test_autonicer.py::test_nometa PASSED                                                   [ 65%]
tests/test_autonicer.py::test_no_primary_obsid PASSED                                         [ 69%]
tests/test_autonicer.py::test_decompress PASSED                                               [ 73%]
tests/test_autonicer.py::test_checkcal PASSED                                                 [ 76%]
tests/test_autonicer.py::test_no_caldb PASSED                                                 [ 80%]
tests/test_autonicer.py::test_reprocess PASSED                                                [ 84%]
tests/test_autonicer.py::test_checkcal_reprocess PASSED                                       [ 88%]
tests/test_autonicer.py::test_inlist_singledir PASSED                                         [ 92%]
tests/test_autonicer.py::test_inlist_readin PASSED                                            [ 96%]
tests/test_autonicer.py::test_cleanup PASSED                                                  [100%]

    ---------- coverage: platform linux, python 3.10.6-final-0 -----------
    Name                      Stmts   Miss  Cover   Missing
    -------------------------------------------------------
    autonicer/__init__.py        22      3    86%   69-71
    autonicer/autonicer.py      261     43    84%   68, 70, 72, 74, 76-90, 104-107, 193-196, 200-202, 208-209, 223-224, 231-232, 236, 262-265, 278, 327, 367, 372-373, 381
    autonicer/reprocess.py      170      4    98%   113-114, 196-198
    tests/__init__.py             0      0   100%
    tests/test_autonicer.py     238      2    99%   278-279
    -------------------------------------------------------
    TOTAL                       691     52    92%
