### PR TITLE
Bump to v1.2.7 for temp fix by pegging astroquery==0.4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,3 +84,9 @@ autoNICER is a program that allows individuals wanting to work with data from th
 ### v1.2.5
 - Fixed vulnerabilites with cryptography dep (CVE-2023-0286 and CVE-2023-23931)
 
+### v1.2.6
+- Updated astroquery depencency to dev version of 0.4.7 or newer
+- Added cache clearing upon each new session
+
+### v1.2.7
+- Pegged astroquery dependency to 0.4.7 due to breaking changes introduced in astroquery >= 0.4.8

--- a/autonicer/autonicer.py
+++ b/autonicer/autonicer.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 
 # AutoNICER
-# Copyright 2022-2023 Nicholas Kuechel
+# Copyright 2022-2025 Nicholas Kuechel
 # License Apache 2.0
 
 import subprocess as sp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "autonicer"
-version = "1.2.6"
+version = "1.2.7"
 description = "A program that retrieves NICER observational data sets and performs a default data reduction process on the NICER observational data"
 authors = [
   {name = "Tsar Bomba Nick", email = "njkuechel@protonmail.com" }
@@ -14,7 +14,7 @@ readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
     "astropy >= 4.2.1",
-    "astroquery >= 0.4.7.dev8479",
+    "astroquery == 0.4.7",
     "numpy >= 1.20.3",
     "pandas >= 1.2.4",
     "termcolor >= 1.1.0",


### PR DESCRIPTION
This PR introduces a temporary patch to #61 by pegging the astroquery dependency to 0.4.7 since breaking changes were introduced in version greater than 0.4.8.

A more significant rewrite will be needed for a more long term fix, but that will require evaluating whether or not the astroquery dependency is stable enough to proceed using it, or in an internally developed solution will be more reliable.

As per the title this will bump to v1.2.7 since this is a minor tweak.