### PR TITLE
Add async-requests/downloads for data and general refactor for v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,53 +1,49 @@
 # autoNICER
 
-Author: Nicholas Kuechel a.k.a. Nick The Space Cowboy a.k.a. Tsar Bomba Nick
+Author: Nicholas Kuechel a.k.a. Nick Space Cowboy a.k.a. Tsar Bomba Nick
 
 ## Description: 
 
-autoNICER is a program that allows individuals wanting to work with data from the NICER mission to automatically retrieve observational data, reduce observational the retrieved observational data through a standardized data reduction scheme, and then compress less commonly used files from the observational data set to conserve space. 
+autoNICER is a program that allows individuals wanting to work with data from the NICER mission to automatically retrieve observational data, reduce observational the retrieved observational data through a standardized data reduction scheme, and then compress less commonly used files from the observational data set to conserve space.
 
-## Changes Pre-v1.0.0 release
-- Original version of this code specifically written for work on a small VM
-- Elimination of the count rate functionality tool
-- Streamiling so it runs from the directory its called in
-- Changed the barycenter correction to include the modern ephemeris set to JPLEPH.430 and to custom set RA and DEC without changing the code
-- Added further automation to pull directly from heasarc
-	- Auto pulls year, month, ra, and dec
-- Added auto queing generation option 
-- Added automatic tar.gz compression to all .evt files with the exception of the bary-center corrected mpu7_cl.evt file
-- Fixed issue of outpath not being fully written out in the output que
+### v1.3.0
+- Added async requests for downloading NICER datasets and dropped `wget` dependency, smaller files set to download asynchronously, while large files are still downloaded synchronously
+- Moved data retrieval from HEASARC FTP servers to AWS S3 bucket for faster download speeds
+- Bumped astroquery dependency to >= 0.4.8
+- Refactored `AutoNICER` class attributes to work off of a single queue of dicts rather than multiple list attributes
+- Added logging set to info level
+- Added `--version` to cli and updated `--inlist` dest and description
 
-### v1.0.0
-- Added cycle selection functionality with the command "cycle [cycle #]"
-- Added rm command to remove either all selected obsid's with `rm all`, or a specific obsid with `rm obsid` where "obsid" is the observation ID we want removed from the processing queue
+### v1.2.7
+- Pegged astroquery dependency to 0.4.7 due to breaking changes introduced in astroquery >= 0.4.8
 
-### v1.0.1
-- PRIMARY: Changed the way output ques/logs are written out. Users may now select if they want to add to an exisiting log file or create a new log file.
-- SECONDARY: Added testing of functions that can be tested without requiring the retrieval of NICER observational data for CI testing on the github end. 
-- Added coloration of text in the terminal when running autoNICER so a user can be more aware of the where in the procedure autoNICER is.
+### v1.2.6
+- Updated astroquery depencency to dev version of 0.4.7 or newer
+- Added cache clearing upon each new session
 
-### v1.0.2
-- Limited the astropy dependency to versions less than v5.1 since the changes in astropy v5.1 mess with the time conversions. (Future versions will make autonicer compatable with astropy v5.1)
+### v1.2.5
+- Fixed vulnerabilites with cryptography dep (CVE-2023-0286 and CVE-2023-23931)
 
-### v1.1.0
-- Added two new columns to the output log: CALDB_ver and DateTime. Also changed the "Name" column to "OBSID". This should lead to less confusion and give the user a better idea of which calibration version was used to process their data, and at what point in time they processed that data.
+### v1.2.4
+- Added in multi-threaded compression/decompression of files (should speed up runtime)
+- Re-added in compression of non barycenter corrected mpu7_cl.evt files if a barycenter corrrected cl.evt file is created
+- Fixed bug with an unexpected `Target: ` prompt appearing if OBJECT metadata cannot be found
+- Fixed bug with auto-detection of barycenter correction parsing
 
-### v1.1.1
-- Error handling for the done command
-- Error handling for OBSIDs that do not exist in the nicermastr query
-- Error handling for OBSID entries that are too short
-- Fixed new issue where autonicer runs pull_reduce after each command
-- Enhanced testing of commands
-- Removed pull_reduce call from the init and added it under the done command
+### v1.2.3
+- Fixed error handling messages for missing metadata in cl.evt files
+- Switched the pull of required metadata from hdu 0 (primary header) to hdu 1 (event header) for the cl.evt NICER files
+- Added OBSID corolation for easier identification
 
-### v1.1.2
-- Error handling for duplicate obsid entries from the autoNICER prompt
-- Error handling for src not resolving in HEASARC nicermastr
-- Added `settings` command to display current settings
-- Added `--src` flag that can be called from the command line to set the src with default settings (i.e. `$ autonicer --src=DESIRED-SRC`)
+### v1.2.2
+- Migrated sp.run("ls STUFF") commands to glob
+- Limited get_caldb_ver() pulls to once per run of autonicer rather than once per OBSID passed in
+- Added error handling for datasets lacking the required metadata
+- Added unix like passthrough to `--inlist` so use cases like `--inlist *` will pass in all datasets for the current working dir
 
-### v1.1.3
-- Fixed bug with single OBSID not resolving. When querying HEASARC sometimes an extra space would be in the OBSID which lead to the resolving issues.
+### v1.2.1
+- Fixed vulnerability with CVE-2022-2341
+- Fixed issue where --checkcal kills --inlist cmd
 
 ### v1.2.0
 - Added `--checkcal` CLI option to check if calibrations are up to date with an existing NICER OBSID dataset
@@ -60,33 +56,45 @@ autoNICER is a program that allows individuals wanting to work with data from th
 - Significant additions to testing taking coverage >= 90%
 - Resolved dependency vulnerability with CVE-2022-42969
 
-### v1.2.1
-- Fixed vulnerability with CVE-2022-2341
-- Fixed issue where --checkcal kills --inlist cmd  
+### v1.1.3
+- Fixed bug with single OBSID not resolving. When querying HEASARC sometimes an extra space would be in the OBSID which lead to the resolving issues.
 
-### v1.2.2
-- Migrated sp.run("ls STUFF") commands to glob
-- Limited get_caldb_ver() pulls to once per run of autonicer rather than once per OBSID passed in
-- Added error handling for datasets lacking the required metadata
-- Added unix like passthrough to `--inlist` so use cases like `--inlist *` will pass in all datasets for the current working dir
+### v1.1.2
+- Error handling for duplicate obsid entries from the autoNICER prompt
+- Error handling for src not resolving in HEASARC nicermastr
+- Added `settings` command to display current settings
+- Added `--src` flag that can be called from the command line to set the src with default settings (i.e. `$ autonicer --src=DESIRED-SRC`)
 
-### v1.2.3
-- Fixed error handling messages for missing metadata in cl.evt files
-- Switched the pull of required metadata from hdu 0 (primary header) to hdu 1 (event header) for the cl.evt NICER files
-- Added OBSID corolation for easier identification
+### v1.1.1
+- Error handling for the done command
+- Error handling for OBSIDs that do not exist in the nicermastr query
+- Error handling for OBSID entries that are too short
+- Fixed new issue where autonicer runs pull_reduce after each command
+- Enhanced testing of commands
+- Removed pull_reduce call from the init and added it under the done command
 
-### v1.2.4
-- Added in multi-threaded compression/decompression of files (should speed up runtime)
-- Re-added in compression of non barycenter corrected mpu7_cl.evt files if a barycenter corrrected cl.evt file is created
-- Fixed bug with an unexpected `Target: ` prompt appearing if OBJECT metadata cannot be found
-- Fixed bug with auto-detection of barycenter correction parsing
+### v1.1.0
+- Added two new columns to the output log: CALDB_ver and DateTime. Also changed the "Name" column to "OBSID". This should lead to less confusion and give the user a better idea of which calibration version was used to process their data, and at what point in time they processed that data.
 
-### v1.2.5
-- Fixed vulnerabilites with cryptography dep (CVE-2023-0286 and CVE-2023-23931)
+### v1.0.2
+- Limited the astropy dependency to versions less than v5.1 since the changes in astropy v5.1 mess with the time conversions. (Future versions will make autonicer compatable with astropy v5.1)
 
-### v1.2.6
-- Updated astroquery depencency to dev version of 0.4.7 or newer
-- Added cache clearing upon each new session
+### v1.0.1
+- PRIMARY: Changed the way output ques/logs are written out. Users may now select if they want to add to an exisiting log file or create a new log file.
+- SECONDARY: Added testing of functions that can be tested without requiring the retrieval of NICER observational data for CI testing on the github end. 
+- Added coloration of text in the terminal when running autoNICER so a user can be more aware of the where in the procedure autoNICER is.
 
-### v1.2.7
-- Pegged astroquery dependency to 0.4.7 due to breaking changes introduced in astroquery >= 0.4.8
+### v1.0.0
+- Added cycle selection functionality with the command "cycle [cycle #]"
+- Added rm command to remove either all selected obsid's with `rm all`, or a specific obsid with `rm obsid` where "obsid" is the observation ID we want removed from the processing queue
+
+## Changes Pre-v1.0.0 release
+- Original version of this code specifically written for work on a small VM
+- Elimination of the count rate functionality tool
+- Streamiling so it runs from the directory its called in
+- Changed the barycenter correction to include the modern ephemeris set to JPLEPH.430 and to custom set RA and DEC without changing the code
+- Added further automation to pull directly from heasarc
+	- Auto pulls year, month, ra, and dec
+- Added auto queing generation option 
+- Added automatic tar.gz compression to all .evt files with the exception of the bary-center corrected mpu7_cl.evt file
+- Fixed issue of outpath not being fully written out in the output que

--- a/README.md
+++ b/README.md
@@ -2,20 +2,20 @@
 [![PyPI Downloads](https://img.shields.io/pypi/dm/autonicer.svg?label=PyPI%20downloads)](https://pypi.org/project/autonicer/)
 
 # autoNICER
-A piece of software that allows for the automated retrieval, and default data reduction of NICER data. This software was developed to automate the retrieval of NICER data and perform standardized data reduction on the retrieved NICER data. 
-This project unaffiliated with the NICER team, NASA, the Goddard Space Flight Center (GSFC), and HEASARC. Thus, under no circumstances should anyone consider this project endorsed or recommended by the afformentioned agencies and organizations.
+A CLI that allows for the automated retrieval, and default data reduction of NICER data. This software was developed to automate the retrieval of NICER data and perform standardized data reduction on the retrieved NICER data.
 
 ## Contributing
 Anyone considering contribiting to this project is encouraged to do so.
 Constributing can be something as small as submitting issues you have found or requesting enhancements. Your feedback is incredibly valuable for improving the project.
-All that is asked is that if you wish to contribute code please reach out in one way or another to nkphysics(Nick Space Cowboy), and submit a pull request.
-And if you want to see what's being worked on for future versions check out the open issues tagged as enhancements or the open projects under the projects tab.
+All that is asked is that if you wish to contribute code please reach out in one way or another to nkphysics, and submit a pull request.
+
+If you are reading this and considering contributing, know that you even taking the time to consider contributing is greatly appreciated. 
 
 Thank you. 
 
 ## Disclaimer
-This software is licensed under the Apache 2.0 license, so it is free and open source for you to use.
-This project unaffiliated with the NICER team, NASA, the Goddard Space Flight Center (GSFC), and HEASARC. Under no circumstances should anyone consider this project endorsed or recommended by the afformentioned agencies and organizations.
+This software is licensed under the Apache 2.0 license, so it is free for you to use.
+This project is unaffiliated with the NICER mission, NASA, the Goddard Space Flight Center (GSFC), and HEASARC. Under no circumstances should anyone consider this project endorsed by or recommended by the afformentioned agencies and organizations.
 
 ## Watch a video Tutorial on how to use autoNICER
 After v1.0.2 I a made a video going over autoNICER and demoing some of its functionality.
@@ -26,13 +26,13 @@ For more in depth instructions and documentation check out the wiki:
 <https://github.com/nkphysics/autoNICER/wiki>
 
 ## Pre-Requisite Software
-- HEASoft v6.29-v6.33, MOST RECENT VERSION RECOMMENDED (v6.33 as of 2024-03-01) <https://heasarc.gsfc.nasa.gov/docs/software/lheasoft/>
+- HEASoft v6.29-v6.34, MOST RECENT VERSION RECOMMENDED (v6.34 as of 2025-02-22) <https://heasarc.gsfc.nasa.gov/docs/software/lheasoft/>
 
 A video tutorial on how to generally install heasoft can be found here: <https://youtu.be/3-gobnSEuDo>
 - Remote CALDB <https://heasarc.gsfc.nasa.gov/docs/heasarc/caldb/caldb_remote_access.html>
 
 A video tutorial on how to setup Remote CALDB can be found here: <https://youtu.be/s01DF0cwOvM>
-- wget
+- wget (Only for versions < v1.3.0)
 
 ## Installation
 

--- a/autonicer/__init__.py
+++ b/autonicer/__init__.py
@@ -8,7 +8,8 @@ import argparse as ap
 
 def run(args=None):
     p = ap.ArgumentParser(
-        description="A program for piplining NICER data reduction. Run by just typing autonicer."
+        description=("A program for piplining NICER data reduction. "
+                     "Run by just typing autonicer.")
     )
 
     p.add_argument(
@@ -66,6 +67,6 @@ def run(args=None):
         else:
             inlist(argp)
     else:
-        an = autonicer.AutoNICER(argp.src, argp.bc, argp.compress)
+        an = AutoNICER(argp.src, argp.bc, argp.compress)
         an.call_nicer()
         an.command_center()

--- a/autonicer/__init__.py
+++ b/autonicer/__init__.py
@@ -1,72 +1,12 @@
 from .autonicer import AutoNICER
 from .autonicer import get_caldb_ver
-from .reprocess import reprocess_check
-from .reprocess import inlist
+from .autonicer import run
 from .reprocess import Reprocess
-import argparse as ap
 
 
-def run(args=None):
-    p = ap.ArgumentParser(
-        description=("A program for piplining NICER data reduction. "
-                     "Run by just typing autonicer.")
-    )
-
-    p.add_argument(
-        "-src",
-        "--src",
-        help="Set the src from the command line",
-        type=str,
-    )
-
-    p.add_argument(
-        "-checkcal",
-        "--checkcal",
-        help="Checks if mpu7_cl.evt are up to date with latest NICER calibrations",
-        action="store_true",
-        default=False,
-    )
-
-    p.add_argument(
-        "-reprocess",
-        "--reprocess",
-        help="Engages a reprocessing of calibrations ",
-        action="store_true",
-        default=False,
-    )
-
-    p.add_argument(
-        "-bc",
-        "--bc",
-        help="Engages option for a barycenter correction in data reduction procedure",
-        action="store_true",
-        default=None,
-    )
-
-    p.add_argument(
-        "-compress",
-        "--compress",
-        help="Engages option for .gz compression of ufa.evt files",
-        action="store_true",
-        default=None,
-    )
-
-    p.add_argument(
-        "-i",
-        "-inlist",
-        "--inlist",
-        help="Input .csv list with path to OBSID dirs or mpu7_cl.evt files for use with --reprocess and/or --checkcal",
-        default=None,
-        nargs="+",
-    )
-
-    argp = p.parse_args(args)
-    if argp.checkcal is True or argp.reprocess is True:
-        if argp.inlist is None:
-            reprocess_check(argp)
-        else:
-            inlist(argp)
-    else:
-        an = AutoNICER(argp.src, argp.bc, argp.compress)
-        an.call_nicer()
-        an.command_center()
+__all__ = [
+    "AutoNICER",
+    "get_caldb_ver",
+    "run",
+    "Reprocess",
+]

--- a/autonicer/__main__.py
+++ b/autonicer/__main__.py
@@ -1,4 +1,4 @@
 from . import run
 
 if __name__ == "__main__":
-	run()
+    run()

--- a/autonicer/autonicer.py
+++ b/autonicer/autonicer.py
@@ -22,7 +22,6 @@ import logging
 import argparse as ap
 from .reprocess import reprocess_check
 from .reprocess import inlist
-from astropy.utils.exceptions import AstropyWarning
 from importlib.metadata import version
 
 
@@ -111,7 +110,6 @@ class AutoNICER(object):
         """
         heasarc = Heasarc()
         try:
-            warnings.simplefilter("ignore", category=AstropyWarning)
             Heasarc.clear_cache()
             xti = heasarc.query_object(
                 self.obj, mission="nicermastr"

--- a/autonicer/autonicer.py
+++ b/autonicer/autonicer.py
@@ -81,6 +81,22 @@ async def download_file(url: str) -> None:
                             f"with code: {resp.status}")
 
 
+async def download_obsid(urls: list) -> None:
+    """
+    Downloads all files from urls to make up an entire obsid dataset
+
+    Parameters:
+    urls: list, urls to all files that make up an entire obsid dataset
+    """
+    sem = asyncio.Semaphore(4)
+    async with sem:
+        tasks = []
+        for url in urls:
+            task = asyncio.create_task(download_file(url))
+            tasks.append(task)
+        await asyncio.gather(*tasks)
+
+
 class AutoNICER(object):
     def __init__(self, src=None, bc=None, comp=None):
         self.st = True

--- a/autonicer/autonicer.py
+++ b/autonicer/autonicer.py
@@ -319,6 +319,53 @@ class AutoNICER(object):
         q = pd.concat([q, newline])
         q.to_csv(self.q_path, index=False)
 
+    def _make_download_links(self, info: dict) -> list:
+        """
+        Makes all the download links for each file of an OBSID
+
+        Parameters:
+        info: dict, information from AutoNICER.queue
+                    required to make all download links
+                    (OSBID, year, month, ra, dec)
+
+        Returns:
+        list, all links as str for the given OBSID dataset
+        """
+        base_url = "https://nasa-heasarc.s3.amazonaws.com/nicer/data/obs/"
+        base_url = f"{base_url}{info['year']}_{info['month']}/{info['OBSID']}"
+        file_urls = [f"/log/ni{info['OBSID']}_errlog.html",
+                     f"/log/ni{info['OBSID']}_joblog.html",
+                     f"/auxil/ni{info['OBSID']}.orb.gz",
+                     f"/auxil/ni{info['OBSID']}.mkf.gz",
+                     f"/auxil/ni{info['OBSID']}.cat",
+                     f"/auxil/ni{info['OBSID']}.att.gz",
+                     f"/xti/event_cl/ni{info['OBSID']}_0mpu7_cl.evt.gz",
+                     f"/xti/event_cl/ni{info['OBSID']}_0mpu7_ufa.evt.gz",
+                     f"/xti/event_uf/ni{info['OBSID']}_0mpu0_uf.evt.gz",
+                     f"/xti/event_uf/ni{info['OBSID']}_0mpu1_uf.evt.gz"
+                     f"/xti/event_uf/ni{info['OBSID']}_0mpu2_uf.evt.gz",
+                     f"xti/event_uf/ni{info['OBSID']}_0mpu3_uf.evt.gz",
+                     f"/xti/event_uf/ni{info['OBSID']}_0mpu4_uf.evt.gz",
+                     f"/xti/event_uf/ni{info['OBSID']}_0mpu5_uf.evt.gz",
+                     f"/xti/event_uf/ni{info['OBSID']}_0mpu6_uf.evt.gz",
+                     f"/xti/hk/ni{info['OBSID']}_0mpu0.hk.gz",
+                     f"/xti/hk/ni{info['OBSID']}_0mpu1.hk.gz",
+                     f"/xti/hk/ni{info['OBSID']}_0mpu2.hk.gz",
+                     f"/xti/hk/ni{info['OBSID']}_0mpu3.hk.gz",
+                     f"/xti/hk/ni{info['OBSID']}_0mpu4.hk.gz",
+                     f"/xti/hk/ni{info['OBSID']}_0mpu5.hk.gz",
+                     f"/xti/hk/ni{info['OBSID']}_0mpu6.hk.gz",
+                     f"/xti/products/ni{info['OBSID']}_lc.png",
+                     f"/xti/products/ni{info['OBSID']}_pi.png",
+                     f"/xti/products/ni{info['OBSID']}mpu7.arf.gz",
+                     f"/xti/products/ni{info['OBSID']}mpu7.rmf.gz",
+                     f"/xti/products/ni{info['OBSID']}mpu7_bg.pha.gz",
+                     f"/xti/products/ni{info['OBSID']}mpu7_load.xcm.gz",
+                     f"/xti/products/ni{info['OBSID']}mpu7_sk.arf.gz",
+                     f"/xti/products/ni{info['OBSID']}mpu7_sr.lc.gz",
+                     f"/xti/products/ni{info['OBSID']}mpu7_sr.pha.gz"]
+        return [f"{base_url}{url}" for url in file_urls]
+
     def reduce(self, data):
         """
         Performs standardized data reduction scheme calling

--- a/autonicer/autonicer.py
+++ b/autonicer/autonicer.py
@@ -538,9 +538,10 @@ def run(args=None):
 
     p.add_argument(
         "-i",
-        "-inlist",
         "--inlist",
-        help=("Input .csv list with path to OBSID dirs or mpu7_cl.evt "
+        dest="inlist",
+        help=(".csv or Unix style pathname pattern whhich lists paths "
+              "to OBSID dirs or mpu7_cl.evt "
               "files for use with --reprocess and/or --checkcal"),
         default=None,
         nargs="+",

--- a/autonicer/autonicer.py
+++ b/autonicer/autonicer.py
@@ -546,6 +546,12 @@ def run(args=None):
         nargs="+",
     )
 
+    p.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {VERSION}"
+    )
+
     argp = p.parse_args(args)
 
     level = logging.INFO

--- a/autonicer/autonicer.py
+++ b/autonicer/autonicer.py
@@ -19,6 +19,9 @@ import warnings
 import glob
 import concurrent.futures
 import logging
+import argparse as ap
+from .reprocess import reprocess_check
+from .reprocess import inlist
 from astropy.utils.exceptions import AstropyWarning
 from importlib.metadata import version
 
@@ -408,3 +411,72 @@ class AutoNICER(object):
                 self.add2q(q, base_dir, obsid)
             else:
                 pass
+
+
+def run(args=None):
+    p = ap.ArgumentParser(
+        description=("A program for piplining NICER data reduction. "
+                     "Run by just typing autonicer.")
+    )
+
+    p.add_argument(
+        "-src",
+        "--src",
+        help="Set the src from the command line",
+        type=str,
+    )
+
+    p.add_argument(
+        "-checkcal",
+        "--checkcal",
+        help=("Checks if mpu7_cl.evt are up to date "
+              "with latest NICER calibrations"),
+        action="store_true",
+        default=False,
+    )
+
+    p.add_argument(
+        "-reprocess",
+        "--reprocess",
+        help="Engages a reprocessing of calibrations ",
+        action="store_true",
+        default=False,
+    )
+
+    p.add_argument(
+        "-bc",
+        "--bc",
+        help=("Engages option for a barycenter correction "
+              "in data reduction procedure"),
+        action="store_true",
+        default=None,
+    )
+
+    p.add_argument(
+        "-compress",
+        "--compress",
+        help="Engages option for .gz compression of ufa.evt files",
+        action="store_true",
+        default=None,
+    )
+
+    p.add_argument(
+        "-i",
+        "-inlist",
+        "--inlist",
+        help=("Input .csv list with path to OBSID dirs or mpu7_cl.evt "
+              "files for use with --reprocess and/or --checkcal"),
+        default=None,
+        nargs="+",
+    )
+
+    argp = p.parse_args(args)
+    if argp.checkcal is True or argp.reprocess is True:
+        if argp.inlist is None:
+            reprocess_check(argp)
+        else:
+            inlist(argp)
+    else:
+        an = AutoNICER(argp.src, argp.bc, argp.compress)
+        an.call_nicer()
+        an.command_center()

--- a/autonicer/autonicer.py
+++ b/autonicer/autonicer.py
@@ -62,7 +62,7 @@ async def download_file(url: str) -> None:
                 file_size = int(resp.headers['Content-Length'])
                 with open(file_path, 'wb') as fd:
                     progress = tqdm(total=file_size, desc=file_name,
-                                    unit="B", unit_scale=True)
+                                    unit="B", unit_scale=True, leave=False)
                     while True:
                         try:
                             chunk = await resp.content.read(1024)
@@ -342,8 +342,8 @@ class AutoNICER(object):
                 os.remove(file)
                 return f"{file} -> {file}.gz"
 
-        logger.info("Compressing ufa.evt files")
-        logger.info(("-" * 50) + "\n")
+        logger.info("\nCompressing ufa.evt files")
+        logger.info("-" * 50)
         # files and loop to compress the ufa files
         files = glob.glob("*ufa.evt")
         with concurrent.futures.ThreadPoolExecutor() as executor:
@@ -355,8 +355,8 @@ class AutoNICER(object):
         # compression of the non-bc mpu7_cl.evt file
         # if barycenter correction is selected
         if self.bc_sel.lower() == "y":
-            logger.info("Compressing cl.evt files")
-            logger.info(("-" * 50) + "\n")
+            logger.info("\nCompressing cl.evt files")
+            logger.info("-" * 50)
             cl_file = glob.glob("ni*cl.evt")
             for i in cl_file:
                 logger.info(gz_comp(i))
@@ -377,7 +377,7 @@ class AutoNICER(object):
         q = pd.concat([q, newline])
         q.to_csv(self.q_path, index=False)
 
-    def _make_download_links(self, info: dict) -> list:
+    def _make_download_links(self, info: dict) -> dict:
         """
         Makes all the download links for each file of an OBSID
 
@@ -391,44 +391,49 @@ class AutoNICER(object):
         """
         base_url = "https://nasa-heasarc.s3.amazonaws.com/nicer/data/obs/"
         base_url = f"{base_url}{info['year']}_{info['month']}/{info['OBSID']}"
-        file_urls = [f"/log/ni{info['OBSID']}_errlog.html",
-                     f"/log/ni{info['OBSID']}_joblog.html",
-                     f"/auxil/ni{info['OBSID']}.orb.gz",
-                     f"/auxil/ni{info['OBSID']}.mkf.gz",
-                     f"/auxil/ni{info['OBSID']}.cat",
-                     f"/auxil/ni{info['OBSID']}.att.gz",
-                     f"/xti/event_cl/ni{info['OBSID']}_0mpu7_cl.evt.gz",
-                     f"/xti/event_cl/ni{info['OBSID']}_0mpu7_ufa.evt.gz",
-                     f"/xti/event_uf/ni{info['OBSID']}_0mpu0_uf.evt.gz",
-                     f"/xti/event_uf/ni{info['OBSID']}_0mpu1_uf.evt.gz",
-                     f"/xti/event_uf/ni{info['OBSID']}_0mpu2_uf.evt.gz",
-                     f"/xti/event_uf/ni{info['OBSID']}_0mpu3_uf.evt.gz",
-                     f"/xti/event_uf/ni{info['OBSID']}_0mpu4_uf.evt.gz",
-                     f"/xti/event_uf/ni{info['OBSID']}_0mpu5_uf.evt.gz",
-                     f"/xti/event_uf/ni{info['OBSID']}_0mpu6_uf.evt.gz",
-                     f"/xti/hk/ni{info['OBSID']}_0mpu0.hk.gz",
-                     f"/xti/hk/ni{info['OBSID']}_0mpu1.hk.gz",
-                     f"/xti/hk/ni{info['OBSID']}_0mpu2.hk.gz",
-                     f"/xti/hk/ni{info['OBSID']}_0mpu3.hk.gz",
-                     f"/xti/hk/ni{info['OBSID']}_0mpu4.hk.gz",
-                     f"/xti/hk/ni{info['OBSID']}_0mpu5.hk.gz",
-                     f"/xti/hk/ni{info['OBSID']}_0mpu6.hk.gz",
-                     f"/xti/products/ni{info['OBSID']}_lc.png",
-                     f"/xti/products/ni{info['OBSID']}_pi.png",
-                     f"/xti/products/ni{info['OBSID']}mpu7.arf.gz",
-                     f"/xti/products/ni{info['OBSID']}mpu7.rmf.gz",
-                     f"/xti/products/ni{info['OBSID']}mpu7_bg.pha.gz",
-                     f"/xti/products/ni{info['OBSID']}mpu7_load.xcm.gz",
-                     f"/xti/products/ni{info['OBSID']}mpu7_sk.arf.gz",
-                     f"/xti/products/ni{info['OBSID']}mpu7_sr.lc.gz",
-                     f"/xti/products/ni{info['OBSID']}mpu7_sr.pha.gz"]
-        return [f"{base_url}{url}" for url in file_urls]
+        file_urls = {
+            "small": [f"/log/ni{info['OBSID']}_errlog.html",
+                      f"/log/ni{info['OBSID']}_joblog.html",
+                      f"/auxil/ni{info['OBSID']}.orb.gz",
+                      f"/auxil/ni{info['OBSID']}.cat",
+                      f"/xti/hk/ni{info['OBSID']}_0mpu0.hk.gz",
+                      f"/xti/hk/ni{info['OBSID']}_0mpu1.hk.gz",
+                      f"/xti/hk/ni{info['OBSID']}_0mpu2.hk.gz",
+                      f"/xti/hk/ni{info['OBSID']}_0mpu3.hk.gz",
+                      f"/xti/hk/ni{info['OBSID']}_0mpu4.hk.gz",
+                      f"/xti/hk/ni{info['OBSID']}_0mpu5.hk.gz",
+                      f"/xti/hk/ni{info['OBSID']}_0mpu6.hk.gz",
+                      f"/xti/products/ni{info['OBSID']}_lc.png",
+                      f"/xti/products/ni{info['OBSID']}_pi.png",
+                      f"/xti/products/ni{info['OBSID']}mpu7_load.xcm.gz",
+                      f"/xti/products/ni{info['OBSID']}mpu7_sr.lc.gz",
+                      f"/xti/products/ni{info['OBSID']}mpu7_sr.pha.gz",
+                      f"/xti/products/ni{info['OBSID']}mpu7_bg.pha.gz"],
+            "big": [f"/auxil/ni{info['OBSID']}.mkf.gz",
+                    f"/auxil/ni{info['OBSID']}.att.gz",
+                    f"/xti/event_cl/ni{info['OBSID']}_0mpu7_cl.evt.gz",
+                    f"/xti/event_cl/ni{info['OBSID']}_0mpu7_ufa.evt.gz",
+                    f"/xti/event_uf/ni{info['OBSID']}_0mpu0_uf.evt.gz",
+                    f"/xti/event_uf/ni{info['OBSID']}_0mpu1_uf.evt.gz",
+                    f"/xti/event_uf/ni{info['OBSID']}_0mpu2_uf.evt.gz",
+                    f"/xti/event_uf/ni{info['OBSID']}_0mpu3_uf.evt.gz",
+                    f"/xti/event_uf/ni{info['OBSID']}_0mpu4_uf.evt.gz",
+                    f"/xti/event_uf/ni{info['OBSID']}_0mpu5_uf.evt.gz",
+                    f"/xti/event_uf/ni{info['OBSID']}_0mpu6_uf.evt.gz",
+                    f"/xti/products/ni{info['OBSID']}mpu7.arf.gz",
+                    f"/xti/products/ni{info['OBSID']}mpu7.rmf.gz",
+                    f"/xti/products/ni{info['OBSID']}mpu7_bg.pha.gz",
+                    f"/xti/products/ni{info['OBSID']}mpu7_sk.arf.gz"]
+        }
+        return {"small": [f"{base_url}{url}" for url in file_urls["small"]],
+                "big": [f"{base_url}{url}" for url in file_urls["big"]]}
 
     def reduce(self, data):
         """
         Performs standardized data reduction scheme calling
         nicerl2 and barycorr if set
         """
+        logger.info("\nStarting Data Reduction... \n")
         sp.call(f"nicerl2 indir={data['OBSID']}/ clobber=yes", shell=True)
         if self.bc_sel.lower() == "y":
             sp.call(
@@ -455,9 +460,13 @@ class AutoNICER(object):
             logger.info("-" * 60)
             # Download dataset
             urls = self._make_download_links(data)
-            for url in urls:
+            # Download big
+            logger.info("\nDownloading large files\n")
+            for url in urls["big"]:
                 asyncio.run(download_file(url))
-            # asyncio.run(download_obsid(urls))
+            # Download small
+            logger.info("\nDownloading small files\n")
+            asyncio.run(download_obsid(urls["small"]))
 
             self.caldb_ver = get_caldb_ver()
             self.reduce(data)

--- a/autonicer/autonicer.py
+++ b/autonicer/autonicer.py
@@ -455,7 +455,9 @@ class AutoNICER(object):
             logger.info("-" * 60)
             # Download dataset
             urls = self._make_download_links(data)
-            asyncio.run(download_obsid(urls))
+            for url in urls:
+                asyncio.run(download_file(url))
+            # asyncio.run(download_obsid(urls))
 
             self.caldb_ver = get_caldb_ver()
             self.reduce(data)

--- a/autonicer/autonicer.py
+++ b/autonicer/autonicer.py
@@ -27,8 +27,6 @@ from importlib.metadata import version
 AUTONICER = os.path.basename(sys.argv[0])
 VERSION = version('autonicer')
 logger = logging.getLogger(AUTONICER)
-handler = logging.StreamHandler(stream=sys.stdout)
-logger.addHandler(handler)
 
 
 def get_caldb_ver():
@@ -47,9 +45,6 @@ class AutoNICER(object):
         self.xti = 0
         self.queue = []
         self.caldb_ver = ""
-
-        logger.info(colored("##########  Auto NICER  ##########\n",
-                    "cyan"))
         self.obj = src
         self.bc_sel = bc
         self.q_set = "n"
@@ -452,12 +447,20 @@ def run(args=None):
     )
 
     argp = p.parse_args(args)
+
+    level = logging.INFO
+    logging.basicConfig(stream=sys.stdout,
+                        level=level,
+                        format="")
+
     if argp.checkcal is True or argp.reprocess is True:
         if argp.inlist is None:
             reprocess_check(argp)
         else:
             inlist(argp)
     else:
+        logger.info(colored("##########  Auto NICER  ##########\n",
+                    "cyan"))
         an = AutoNICER(argp.src, argp.bc, argp.compress)
         an.call_nicer()
         an.command_center()

--- a/autonicer/reprocess.py
+++ b/autonicer/reprocess.py
@@ -117,8 +117,9 @@ class Reprocess:
             else:
                 self.calstate = False
                 premessage = "NOT"
-            logger.info(colored(f"{premessage} Up to date with latest NICER CALDB", color))
-            logger.info("")
+            logger.info(colored((f"{premessage} Up to date "
+                                 "with latest NICER CALDB\n"),
+                        color))
             hdul.close()
         os.chdir(self.base_dir)
         return self.calstate
@@ -152,7 +153,7 @@ class Reprocess:
         Reprocesses an existing dataset with latest calibrations
         """
         if self.calstate is True:
-            logger.info(f"----------  Passing Reprocess of {self.obsid}  ----------")
+            logger.info(f"Passing Reprocess of {self.obsid}\n")
         elif self.reprocess_err is True:
             logger.info(colored("!!!!! CANNOT REPROCESS !!!!!"), "red")
         else:
@@ -160,12 +161,13 @@ class Reprocess:
             if bc is True:
                 self.bc_det = bc
             an = autonicer.AutoNICER(src=self.src, bc=self.bc_det, comp=False)
-            an.observations.append(self.obsid)
-            an.ras.append(self.ra)
-            an.decs.append(self.dec)
+            reprocess_dict = {"OBSID": self.obsid,
+                              "ra": self.ra,
+                              "dec": self.dec}
+            an.queue.append(reprocess_dict)
             proc_dir = self.base_dir.split(f"{self.obsid}")
             os.chdir(proc_dir[0])
-            an.reduce(self.obsid)
+            an.reduce(reprocess_dict)
             os.chdir(f"{self.base_dir}/xti/event_cl/")
             if compress is True or self.comp_det is True:
                 an.nicer_compress()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "autonicer"
-version = "1.2.7"
+version = "1.3.0"
 description = "A program that retrieves NICER observational data sets and performs a default data reduction process on the NICER observational data"
 authors = [
   {name = "Tsar Bomba Nick", email = "njkuechel@protonmail.com" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,14 +21,16 @@ dependencies = [
     "certifi >= 2022.12.7",
     "cryptography >= 41.0.2",
     "requests >= 2.31.0",
+    "tqdm >= 4.67.1",
+    "aiohttp >= 3.11.12",
 ]
 
 [project.optional-dependencies]
 dev = [
     "pytest-cov >= 3.0.0",
-    "black >= 22.6.0",
     "pytest >= 7.2.0",
     "build >= 0.10.0",
+    "flake8 >= 7.1.1"
 ]
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
     "astropy >= 4.2.1",
-    "astroquery == 0.4.7",
+    "astroquery >= 0.4.8",
     "numpy >= 1.20.3",
     "pandas >= 1.2.4",
     "termcolor >= 1.1.0",

--- a/tests/test_autonicer.py
+++ b/tests/test_autonicer.py
@@ -44,69 +44,38 @@ def test_make_cycle():
         cnt += 1
 
 
-def lentest(expected):
-    """
-    General test of the observations, years, months, ras, and decs
-    to ensure the expected number of parameters are stored in the
-    respective variables of the AutoNICER object
-    """
-    lens = [
-        len(an.observations),
-        len(an.years),
-        len(an.months),
-        len(an.ras),
-        len(an.decs),
-    ]
-    for i in lens:
-        assert i == expected
-    return True
-
-
-def test_single_sel():
+def test_selections():
+    # test selecting 1 obsid
     an.command_center("1013010112")
-    lt1 = lentest(1)
-    assert an.observations[0] == "1013010112"
-
-
-def test_short_entry():
+    assert an.queue[0]['OBSID'] == "1013010112"
+    assert len(an.queue) == 1
+    # test short entry/ incomplete obsid
     an.command_center("11")
-    lentest(1)
-
-
-def test_wrong_obsid():
+    assert len(an.queue) == 1
+    # test obsid from a different source not queried
     an.command_center("1013010000")
-    lentest(1)
-
-
-def test_cycle_sel():
+    assert len(an.queue) == 1
+    # test selecting by entire cycle
     an.command_center("cycle 1")
-    lentest(59)
-
-
-def test_rm_single_sel():
+    assert len(an.queue) == 59
+    # test removal of specific obsid
     an.command_center("rm 1013010112")
-    assert an.observations.count("1013010112") == 0
-    assert "1013010112" not in an.observations
-    lentest(58)
-
-
-def test_back():
-    last = an.observations[-1]
+    sel_obsids = [i["OBSID"] for i in an.queue]
+    assert "1013010112" not in sel_obsids
+    assert len(an.queue) == 58
+    # test removal of previously inserted obsid
+    last_obsid = sel_obsids[-1]
     an.command_center("back")
-    assert an.observations.count(last) == 0
-    lentest(57)
-
-
-def test_duplicate():
+    sel_obsids = [i["OBSID"] for i in an.queue]
+    assert last_obsid not in sel_obsids
+    assert len(an.queue) == 57
+    # test duplicates not getting added to the queue
     an.command_center("cycle 1")
-    lentest(59)
+    assert len(an.queue) == 59
     an.command_center("1013010112")
-    lentest(59)
-
-
-def test_rm_all():
+    assert len(an.queue) == 59
     an.command_center("rm all")
-    lentest(0)
+    assert len(an.queue) == 0
 
 
 def test_get_caldbver():

--- a/tests/test_autonicer.py
+++ b/tests/test_autonicer.py
@@ -236,7 +236,7 @@ def test_checkcal_reprocess():
 def test_inlist_singledir():
     os.chdir(f"{base_dir}/data")
     os.remove("test.csv")
-    autonicer.run(["--checkcal", "-inlist", "*"])
+    autonicer.run(["--checkcal", "--inlist", "*"])
 
 
 def test_inlist_readin():

--- a/tests/test_autonicer.py
+++ b/tests/test_autonicer.py
@@ -68,17 +68,6 @@ def test_single_sel():
     assert an.observations[0] == "1013010112"
 
 
-def test_showsettings(capsys):
-    an.command_center("settings")
-    target = f"Target: {an.obj}"
-    bc = f"Barycenter Correction: {an.bc_sel}"
-    comp = f".gz compresion: {an.tar_sel}"
-    settings = [target, bc, comp]
-    out, err = capsys.readouterr()
-    for i in settings:
-        assert i in out
-
-
 def test_short_entry():
     an.command_center("11")
     lentest(1)
@@ -124,15 +113,12 @@ def test_get_caldbver():
     assert autonicer.get_caldb_ver() == "xti20240206"
 
 
-def test_pullreduce(capsys):
+def test_pullreduce():
     an.q_set = "y"
     an.q_name = "test"
     an.command_center("3013010102")
     sel = an.command_center("sel")
     assert sel is True
-    out, err = capsys.readouterr()
-    assert "Observations Selected:" in out
-    assert "3013010102" in out
     an.command_center("done")
     os.chdir(f"{base_dir}/data/3013010102/xti/event_cl/")
     ufa = glob.glob("*ufa.evt")
@@ -175,7 +161,7 @@ metadata = {
 }
 
 
-def test_nometa(capsys):
+def test_nometa():
     os.chdir(f"{base_dir}/data/3013010102/xti/event_cl/")
     cl_files = glob.glob("*cl.evt")
     for i in cl_files:
@@ -190,17 +176,10 @@ def test_nometa(capsys):
     os.chdir(f"{base_dir}/data/3013010102")
     check = autonicer.Reprocess()
     check.reprocess()
-    out, err = capsys.readouterr()
-    fail = "Consider Re-downloading and reducing this dataset"
-    fail_reprocess = "!!!!! CANNOT REPROCESS !!!!!"
-    no_obsid = colored("Unable to idenify OBSID", "red")
-    assert no_obsid in out
-    assert fail in out
-    assert fail_reprocess in out
     assert check.reprocess_err is True
 
 
-def test_no_primary_obsid(capsys):
+def test_no_primary_obsid():
     os.chdir(f"{base_dir}/data/3013010102/xti/event_cl/")
     cl_files = glob.glob("*cl.evt")
     for i in cl_files:
@@ -212,7 +191,6 @@ def test_no_primary_obsid(capsys):
         hdul.close()
     os.chdir(f"{base_dir}/data/3013010102")
     check2 = autonicer.Reprocess()
-    out, err = capsys.readouterr()
     assert check2.reprocess_err is None
     assert check2.src is False
 
@@ -240,7 +218,7 @@ def test_checkcal(setup_reprocess):
     os.chdir(f"{base_dir}/data/")
 
 
-def test_no_caldb(capsys, setup_reprocess):
+def test_no_caldb(setup_reprocess):
     os.chdir(f"{base_dir}/data/3013010102/xti/event_cl/")
     cl_files = glob.glob("*cl.evt")
     for i in cl_files:
@@ -250,9 +228,6 @@ def test_no_caldb(capsys, setup_reprocess):
         hdul.close()
     check = setup_reprocess
     check.checkcal()
-    out, err = capsys.readouterr()
-    fail = "!!!!! CANNOT IDENTIFY CALDB !!!!!"
-    assert fail in out
 
 
 def get_processed_time(file):
@@ -275,7 +250,7 @@ def test_reprocess(setup_reprocess):
     assert post_bc_dt > pre_bc_dt
 
 
-def test_checkcal_reprocess(capsys):
+def test_checkcal_reprocess():
     try:
         os.chdir(f"{base_dir}/data")
         files = ["test.csv", "fail.lis", "*"]
@@ -287,34 +262,19 @@ def test_checkcal_reprocess(capsys):
                            f"--inlist={i}"])
     except SystemExit:
         pass
-    out, err = capsys.readouterr()
-    passing = f"----------  Passing Reprocess of 3013010102  ----------"
-    fail = "DATASETS NOT FOUND"
-    unix = f"Migrating to {colored('3013010102', 'cyan')}"
-    unix2 = "test.csv is not a directory! Passing..."
-    assert passing in out
-    assert fail in out
-    assert unix in out
-    assert unix2 in out
 
 
-def test_inlist_singledir(capsys):
+def test_inlist_singledir():
     os.chdir(f"{base_dir}/data")
     os.remove("test.csv")
     autonicer.run(["--checkcal", "-inlist", "*"])
-    passing = f"Migrating to {colored('3013010102', 'cyan')}"
-    out, err = capsys.readouterr()
-    assert passing in out
 
 
-def test_inlist_readin(capsys):
+def test_inlist_readin():
     os.chdir(f"{base_dir}")
     files = ["README.md", "fail.lis"]
     for i in files:
         autonicer.run(["--checkcal", "-i", f"{i}"])
-    out, err = capsys.readouterr()
-    pd_err = "Unable to resolve --inlist README.md"
-    assert pd_err in out
 
 
 def test_cleanup():


### PR DESCRIPTION
This PR is to resolve #61 and resolve #60 by adding in code to do async requests/downloads of NICER data and to work with `astroquery >= 0.4.8`. Also refactoring was performed to make the program more maintainable and to have usable logging.

The following changes regarding refactoring were made:

- Moved from print statements to info logs
- Removed Astropy warning filters from Heasarc.heasarc() requests
- moved `run()` out of the __init__ file and into autonicer
- Replaced `AutoNICER` attributes for obsid, ra, dec, year, and month, to a single queue  (list) of dicts containing all information for a selected obsid
- Switched from deprecated `heasarc.query_object()` to `heasarc.query_region()` with `SkyCoord` for querying `nicermastr`
- Changed `AutoNICER.pull_reduce()` to download large files synchronously and all small files asynchronously.

The following new code introduced is as follows:

- Created async `download_file()` using aiohttp and tqdm to download an individual file
- Created async `download_obsid()` to download obsid files asynchronously
- Added `AutoNICER._make_download_links()` to generate links to all files that make up a NICER obsid dataset
- Added `--version` to the cli